### PR TITLE
Add `skills` array to site config to prevent About rendering error

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,15 @@ export const siteConfig = {
     github: "https://github.com/eithannak29",
   },
   aboutMe: "AI enjoyer 🤠, focused on Large Language Models & Deep Learning.",
+  skills: [
+    "Large Language Models",
+    "Deep Learning",
+    "Multimodal ML",
+    "RAG",
+    "Computer Vision",
+    "PyTorch",
+    "Python",
+  ],
 
   projects: [
     {


### PR DESCRIPTION
### Motivation
- The About component calls `siteConfig.skills.map(...)` which caused a build-time `Cannot read properties of undefined (reading 'map')`, so provide a default `skills` array to ensure safe rendering.

### Description
- Added a `skills` array to `src/config.ts` containing several skill strings so `siteConfig.skills` is defined for the About section.

### Testing
- No automated tests were run after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69702448e8308329be20a8ed5937d2be)